### PR TITLE
fixed app.yaml for r1.1a

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -18,9 +18,6 @@ libraries:
 - name: MySQLdb
   version: "latest"
 
-builtins:
-- django_wsgi: on
-
 env_variables:
   DJANGO_SETTINGS_MODULE: 'pw_django.settings'
   DATABASE_URL: 'mysql://root:password@bafghahi-website:main/blog'


### PR DESCRIPTION
GAE release failed because:

> Deployment failed. Details: Deployment failed, details: { Failed to load application, Line 21, column 14: Unable to find property 'django_wsgi' on class: > com.google.cloud.services.infrastructure.controller.appengine.PreparedAppYaml$Builtin, none}

This might fix it.
